### PR TITLE
ehci-exynos: Allow to specify clken_polarity from env

### DIFF
--- a/drivers/usb/host/ehci-exynos.c
+++ b/drivers/usb/host/ehci-exynos.c
@@ -217,17 +217,22 @@ u32     phypwr, phyclk, rstcon, a;
 
 void usb_hub_init () {
 	u32	a, val, i2c_dat;
-
+	int clk_inv;
+	
 #define GPX3BASE ((void *) (0x11000C60))
 
 	/* Start */
 	gpio_direction_output(GPX3BASE, 5, 0);
 	gpio_set_value(GPX3BASE, 5, 0);
 	mdelay(10);
+	
+	clk_inv = getenv_yesno("usb_invert_clken");
+	printf("usb: usb_refclk_enable is active low: %s\n", clk_inv ? "NO" : "YES");
+	printf("ProTIP: If usb doesn't work - try playing with 'usb_invert_clken' environment\n");
 
 	/* RefCLK 24MHz */
 	gpio_direction_output(GPX3BASE, 0, 0);
-	gpio_set_value(GPX3BASE, 0, 0);
+	gpio_set_value(GPX3BASE, 0, clk_inv);
 	mdelay(10);
 
 	gpio_direction_output(GPX3BASE, 4, 0);

--- a/include/env_default.h
+++ b/include/env_default.h
@@ -27,6 +27,7 @@ const unsigned char default_environment[] = {
     "default_bootcmd=echo >>> Run Default Bootcmd <<<;movi read kernel 0 40008000;movi read rootfs 0 41000000 100000;bootm 40008000 41000000\0"
     "loadbootscript_1=echo >>> Load Boot Script from mmc 0:1 <<<;fatload mmc 0:1 40008000 boot.scr\0"
     "loadbootscript_2=echo >>> Load Boot Script from mmc 0:2 <<<;fatload mmc 0:2 40008000 boot.scr\0"
+    "usb_invert_clken=0\0"
 #endif
 
 #ifdef	CONFIG_ENV_CALLBACK_LIST_DEFAULT


### PR DESCRIPTION
ODROID-X2 boards expect active high to enable 24Mhz clock
This patch introduces 'usb_invert_clken' environment variable
that does the trick.
For X2 boards - set to 1, for U/U2 - set to 0 (default)
This fixes SMSC USB-Network and USB in general not working on X2 in u-boot

Signed-off-by: Andrew Andrianov andrew@ncrmnt.org
