### PR TITLE
Adding to build ".arch_extension sec" conditionally

### DIFF
--- a/board/samsung/smdk4212/smc.c
+++ b/board/samsung/smdk4212/smc.c
@@ -90,7 +90,9 @@ static inline u32 exynos_smc(u32 cmd, u32 arg1, u32 arg2, u32 arg3)
 	register u32 reg3 __asm__("r3") = arg3;
 
 	__asm__ volatile (
+#if __GNUC__ >= 4 && __GNUC_MINOR__ >= 6
 		".arch_extension sec\n"
+#endif
 		"smc	0\n"
 		: "+r"(reg0), "+r"(reg1), "+r"(reg2), "+r"(reg3)
 
@@ -105,7 +107,9 @@ static inline u32 exynos_smc_read(u32 cmd)
 	register u32 reg1 __asm__("r1") = 0;
 
 	__asm__ volatile (
+#if __GNUC__ >= 4 && __GNUC_MINOR__ >= 6
 		".arch_extension sec\n"
+#endif
 		"smc	0\n"
 		: "+r"(reg0), "+r"(reg1)
 


### PR DESCRIPTION
Added preprocessor to check gcc version for ".arch_extension sec" since
gcc-4.6 support it.

Signed-off-by: Dongjin Kim dongjin.kim@agreeyamobility.net
