### PR TITLE
use lldiv() for 64-bit division

### DIFF
--- a/drivers/mmc/aml_sd_mmc.c
+++ b/drivers/mmc/aml_sd_mmc.c
@@ -15,6 +15,7 @@
 #include <asm/arch/io.h>
 #include <asm/arch/sdio.h>
 #include <mmc.h>
+#include <div64.h>
 
 #ifdef CONFIG_STORE_COMPATIBLE
 #include <asm/arch/storage.h>
@@ -449,7 +450,7 @@ int aml_sd_send_cmd(struct mmc *mmc, struct mmc_cmd *cmd, struct	mmc_data *data)
 	case MMC_CMD_WRITE_SINGLE_BLOCK:
 	case MMC_CMD_WRITE_MULTIPLE_BLOCK:
 		if(mmc->high_capacity)
-			ret = mmc->capacity/mmc->read_bl_len <= cmd->cmdarg;
+			ret = lldiv(mmc->capacity,mmc->read_bl_len) <= cmd->cmdarg;
 		else
 			ret = mmc->capacity <= cmd->cmdarg;
 		if(ret)

--- a/drivers/mmc/mmc.c
+++ b/drivers/mmc/mmc.c
@@ -1144,7 +1144,7 @@ int mmc_startup(struct mmc *mmc)
 	mmc->block_dev.lun = 0;
 	mmc->block_dev.type = 0;
 	mmc->block_dev.blksz = mmc->read_bl_len;
-	mmc->block_dev.lba = mmc->capacity/mmc->read_bl_len;
+	mmc->block_dev.lba = lldiv(mmc->capacity,mmc->read_bl_len);
 	sprintf(mmc->block_dev.vendor,"Man %02x%02x%02x Snr %02x%02x%02x%02x",
 			mmc->cid[0], mmc->cid[1], mmc->cid[2],
 			mmc->cid[9], mmc->cid[10], mmc->cid[11], mmc->cid[12]);


### PR DESCRIPTION
Otherwise u-boot will crash with
    Enter Exception:0x00000001

The original Patch was from Ilya Yanok yanok@emcraft.com

Signed-off-by: Christian Ege k4230r6@gmail.com
