### PR TITLE
Update cmd_fat.c

### DIFF
--- a/common/cmd_fat.c
+++ b/common/cmd_fat.c
@@ -298,10 +298,10 @@ int do_fat_cfgload(cmd_tbl_t *cmdtp, int flag, int argc, char *argv[])
     setenv("filesize", "0");
     run_command("if fatload mmc 0:1 5FFF0000 boot.ini;" \
                 "   then echo $msgload FAT;" \
-                "   else if ext4load mmc 0:1 5FFF0000 /boot/boot.ini;" \
-                "   then echo $msgload ext4 0:1;" \
-                "   else if ext4load mmc 0:2 5FFF0000 /boot/boot.ini;" \
-                "   then echo $msgload ext4 0:2;" \
+                "   else if ext2load mmc 0:1 5FFF0000 /boot/boot.ini;" \
+                "   then echo $msgload ext2 0:1;" \
+                "   else if ext2load mmc 0:2 5FFF0000 /boot/boot.ini;" \
+                "   then echo $msgload ext2 0:2;" \
                 "   fi;fi;fi", 0);
     
     if((filesize = getenv_ulong("filesize", 16, 0)))    {
@@ -330,7 +330,7 @@ int do_fat_cfgload(cmd_tbl_t *cmdtp, int flag, int argc, char *argv[])
                 if(wpos < sizeof(cmd)) {
                     if(first)   {
                         if(!strncmp(cmd, "ODROIDXU-UBOOT-CONFIG", sizeof("ODROIDXU-UBOOT-CONFIG"))) {
-                            printf("Find boot.ini file from FAT/Ext4 Area!!\n");     first = 0;
+                            printf("Find boot.ini file from FAT/Ext2 Area!!\n");     first = 0;
                         }
                         else    {
                             printf("Find boot.ini file. But This file is not odroidxu config file!\n");
@@ -355,12 +355,12 @@ int do_fat_cfgload(cmd_tbl_t *cmdtp, int flag, int argc, char *argv[])
 
 U_BOOT_CMD(
 	cfgload, 1, 0, do_fat_cfgload,
-	"cfgload - boot.ini textfile load from FAT32/ext4\n",
+	"cfgload - boot.ini textfile load from FAT32/ext2\n",
 	"<interface(only support mmc 0:1/0:2)>\n"
-	"	- boot.ini file load from FAT32/ext4 on 'interface'\n"
+	"	- boot.ini file load from FAT32/ext2 on 'interface'\n"
 	"Will attempt boot from: \n"
 	"	fat mmc 0:1 /boot.ini\n" 
-        "	ext4 0:1 /boot/boot.ini\n"
-        "	ext4 0:2 /boot/boot.ini\n"
+        "	ext2 0:1 /boot/boot.ini\n"
+        "	ext2 0:2 /boot/boot.ini\n"
         "on the above sequence\n"
 );


### PR DESCRIPTION
replaced ext4load by ext2load

You may either switch on support for ext4\* in current u-boot.bin or replace ext4load by ext2load in cfgload.
