### PR TITLE
Ext4 fixes (invalid extent error on boot)

### DIFF
--- a/fs/ext4/ext4_common.c
+++ b/fs/ext4/ext4_common.c
@@ -1415,6 +1415,7 @@ static struct ext4_extent_header *ext4fs_get_extent_block
 	struct ext4_extent_idx *index;
 	unsigned long long block;
 	struct ext_filesystem *fs = get_fs();
+	int blksz = EXT2_BLOCK_SIZE(data);
 	int i;
 
 	while (1) {
@@ -1438,7 +1439,7 @@ static struct ext4_extent_header *ext4fs_get_extent_block
 		block = le32_to_cpu(index[i].ei_leaf_hi);
 		block = (block << 32) + le32_to_cpu(index[i].ei_leaf_lo);
 
-		if (ext4fs_devread(block << log2_blksz, 0, fs->blksz, buf))
+		if (ext4fs_devread(block << log2_blksz, 0, blksz, buf))
 			ext_block = (struct ext4_extent_header *)buf;
 		else
 			return 0;

--- a/fs/ext4/ext4_common.c
+++ b/fs/ext4/ext4_common.c
@@ -1421,7 +1421,7 @@ static struct ext4_extent_header *ext4fs_get_extent_block
 	while (1) {
 		index = (struct ext4_extent_idx *)(ext_block + 1);
 
-		if (le32_to_cpu(ext_block->eh_magic) != EXT4_EXT_MAGIC)
+		if (le16_to_cpu(ext_block->eh_magic) != EXT4_EXT_MAGIC)
 			return 0;
 
 		if (ext_block->eh_depth == 0)
@@ -1429,14 +1429,14 @@ static struct ext4_extent_header *ext4fs_get_extent_block
 		i = -1;
 		do {
 			i++;
-			if (i >= le32_to_cpu(ext_block->eh_entries))
+			if (i >= le16_to_cpu(ext_block->eh_entries))
 				break;
 		} while (fileblock > le32_to_cpu(index[i].ei_block));
 
 		if (--i < 0)
 			return 0;
 
-		block = le32_to_cpu(index[i].ei_leaf_hi);
+		block = le16_to_cpu(index[i].ei_leaf_hi);
 		block = (block << 32) + le32_to_cpu(index[i].ei_leaf_lo);
 
 		if (ext4fs_devread(block << log2_blksz, 0, blksz, buf))
@@ -1530,7 +1530,7 @@ long int read_allocated_block(struct ext2_inode *inode, int fileblock)
 
 		do {
 			i++;
-			if (i >= le32_to_cpu(ext_block->eh_entries))
+			if (i >= le16_to_cpu(ext_block->eh_entries))
 				break;
 		} while (fileblock >= le32_to_cpu(extent[i].ee_block));
 		if (--i >= 0) {
@@ -1540,7 +1540,7 @@ long int read_allocated_block(struct ext2_inode *inode, int fileblock)
 				return 0;
 			}
 
-			start = le32_to_cpu(extent[i].ee_start_hi);
+			start = le16_to_cpu(extent[i].ee_start_hi);
 			start = (start << 32) +
 					le32_to_cpu(extent[i].ee_start_lo);
 			free(buf);

--- a/fs/ext4/ext4_common.c
+++ b/fs/ext4/ext4_common.c
@@ -1431,7 +1431,7 @@ static struct ext4_extent_header *ext4fs_get_extent_block
 			i++;
 			if (i >= le16_to_cpu(ext_block->eh_entries))
 				break;
-		} while (fileblock > le32_to_cpu(index[i].ei_block));
+		} while (fileblock >= le32_to_cpu(index[i].ei_block));
 
 		if (--i < 0)
 			return 0;


### PR DESCRIPTION
Backported ext4 fixes to avoid invalid extent error on boot

See: 

http://lists.infradead.org/pipermail/barebox/2014-July/020290.html
http://lists.infradead.org/pipermail/barebox/2014-July/020288.html
http://lists.infradead.org/pipermail/barebox/2014-July/020289.html
