### PR TITLE
fs: ext4: fix symlink read function

### DIFF
--- a/fs/ext4/ext4_common.c
+++ b/fs/ext4/ext4_common.c
@@ -2040,7 +2040,7 @@ static char *ext4fs_read_symlink(struct ext2fs_node *node)
 		status = ext4fs_read_file(diro, 0,
 					   __le32_to_cpu(diro->inode.size),
 					   symlink, &actread);
-		if (status == 0) {
+		if ((status < 0) || (actread == 0)) {
 			free(symlink);
 			return 0;
 		}


### PR DESCRIPTION
Without the appended patch from the Denx upstream git
u-boot ext4load cannot follow symlinks correctly.

Please, merge it into the Odroid C2 branch.

Tested with Debian Stretch.

    Signed-off: Heinrich Schuchardt <xypron.glpk@gmx.de>