### PR TITLE
Enabling support for Amlogic Hardware Watchdog with 60 Sec timeout.

### DIFF
--- a/common/board_f.c
+++ b/common/board_f.c
@@ -109,12 +109,12 @@ __weak void blue_led_off(void) {}
 #if defined(CONFIG_WATCHDOG) || defined(CONFIG_HW_WATCHDOG)
 static int init_func_watchdog_init(void)
 {
-# if defined(CONFIG_HW_WATCHDOG) && (defined(CONFIG_BLACKFIN) || \
+# if defined(CONFIG_HW_WATCHDOG) || (defined(CONFIG_BLACKFIN) || \
 	defined(CONFIG_M68K) || defined(CONFIG_MICROBLAZE) || \
 	defined(CONFIG_SH))
 	hw_watchdog_init();
 # endif
-	puts("       Watchdog enabled\n");
+	puts("Watchdog enabled\n");
 	WATCHDOG_RESET();
 
 	return 0;

--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -1,0 +1,12 @@
+config HW_WATCHDOG
+	bool "Enable Hardware Watchdog"
+	help
+	   This config option enables HW WDT support
+	   To disable Amlogic's HW WDT, say N
+
+config AMLOGIC_WATCHDOG
+	bool "Enable Amlogic SoC HW Watchdog"
+	depends on HW_WATCHDOG
+	help
+	   This config option enables Amlogic's S905 HW watchdog
+	   To disable S905 Amlogic's WDT, say N

--- a/drivers/watchdog/Makefile
+++ b/drivers/watchdog/Makefile
@@ -16,3 +16,4 @@ obj-$(CONFIG_XILINX_TB_WATCHDOG) += xilinx_tb_wdt.o
 obj-$(CONFIG_BFIN_WATCHDOG)  += bfin_wdt.o
 obj-$(CONFIG_OMAP_WATCHDOG) += omap_wdt.o
 obj-$(CONFIG_DESIGNWARE_WATCHDOG) += designware_wdt.o
+obj-$(CONFIG_AMLOGIC_WATCHDOG) += s905_wdt.o

--- a/drivers/watchdog/s905_wdt.c
+++ b/drivers/watchdog/s905_wdt.c
@@ -1,0 +1,21 @@
+/*
+ * watchdog.c - driver for Amlogic s905 on-chip watchdog
+ *
+ * Licensed under the GPL-2 or later.
+ */
+#include <common.h>
+#include <watchdog.h>
+#include <asm/arch/watchdog.h>
+
+#define WDT_HW_TIMEOUT 60
+
+void hw_watchdog_init(void)
+{
+  printf("HW WDT Timeout %d Seconds\n", WDT_HW_TIMEOUT);
+  watchdog_init(60 * 1000);
+}
+
+void hw_watchdog_reset(void)
+{
+  watchdog_reset();
+}

--- a/drivers/watchdog/s905_wdt.c
+++ b/drivers/watchdog/s905_wdt.c
@@ -12,7 +12,7 @@
 void hw_watchdog_init(void)
 {
   printf("HW WDT Timeout %d Seconds\n", WDT_HW_TIMEOUT);
-  watchdog_init(60 * 1000);
+  watchdog_init(WDT_HW_TIMEOUT * 1000);
 }
 
 void hw_watchdog_reset(void)


### PR DESCRIPTION
- Created this PR for issue #51.

- Added option in `menuconfig` by editing `Kconfig` file in `drivers/watchdog` directory to enable/disable Amlogic Hardware watchdog.

- Added a new file `s905_wdt.c` under `drivers/watchdog` directory for calling low-level SoC watchdog functions.
