### PR TITLE
ODROID-N2: attempt to boot from uSD before eMMC

### DIFF
--- a/include/configs/odroid-g12-common.h
+++ b/include/configs/odroid-g12-common.h
@@ -94,7 +94,7 @@
 #define ENV_PXE_DEFAULT
 #endif
 
-#define ENV_MMC_LIST_DEFAULT			"mmc_list=0 1\0"
+#define ENV_MMC_LIST_DEFAULT			"mmc_list=1 0\0"
 
 #define ENV_MMC_DEFAULT					\
 	"boot_mmc="					\


### PR DESCRIPTION
I'm sending this PR for consideration as it is causing headaches for people trying to dual-boot Android and CoreELEC.

eMMC has to be physically removed to boot OS on uSD, this means removing the case and removing the eMMC vs just popping the uSD out, which is extremely frustrating for people.

I know BL1 looks for u-boot in the following order EMMC>SD and the original intention was to match this however looking at the reference board files Amlogic register SD first and then EMMC.

If there is no regressions then please consider this for your Android images :)