### PR TITLE
Revert "ODROID-C3: Change PID(Google Inc) for fastboot."

### DIFF
--- a/drivers/usb/gadget/g_dnl.c
+++ b/drivers/usb/gadget/g_dnl.c
@@ -79,7 +79,7 @@ static struct usb_device_descriptor device_desc = {
 	.bDeviceSubClass = 0x02, /*0x02:CDC-modem , 0x00:CDC-serial*/
 
 	.idVendor = 0x18d1,
-	.idProduct = 0x0002,
+	.idProduct = 0x0d02,
 	.iProduct = STRING_PRODUCT,
 	.iSerialNumber = STRING_SERIAL,
 	.bNumConfigurations = 1,


### PR DESCRIPTION
 * this breaks fastboot on windows horribly (no fastboot driver is able to detect the device), reverting this commit fixes it

This reverts commit f52f63394c0383e9d0c78e430944d968c45d85d6.

Change-Id: I9d43eaabd907aeb99cded253fba5108c23e569f7