### PR TITLE
odroidgoA: scripts/dtc: Remove redundant YYLOC global declaration (cherry-pick from upstream)

### DIFF
--- a/scripts/dtc/dtc-lexer.l
+++ b/scripts/dtc/dtc-lexer.l
@@ -38,7 +38,6 @@ LINECOMMENT	"//".*\n
 #include "srcpos.h"
 #include "dtc-parser.tab.h"
 
-YYLTYPE yylloc;
 extern bool treesource_error;
 
 /* CAUTION: this will stop working if we ever use yyless() or yyunput() */

--- a/scripts/dtc/dtc-lexer.lex.c_shipped
+++ b/scripts/dtc/dtc-lexer.lex.c_shipped
@@ -631,7 +631,6 @@ char *yytext;
 #include "srcpos.h"
 #include "dtc-parser.tab.h"
 
-YYLTYPE yylloc;
 extern bool treesource_error;
 
 /* CAUTION: this will stop working if we ever use yyless() or yyunput() */


### PR DESCRIPTION
Cherry-pick https://github.com/u-boot/u-boot/commit/018921ee79 from upstream.

Fix compilation with `-fno-common` (default in GCC 10)

Note that this also updates `scripts/dtc/dtc-lexer.lex.c_shipped`, which no longer exists in upstream
